### PR TITLE
a path to logo file doesn't work use external source

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -2,7 +2,7 @@
 {% block login %}
 <div class='container branding'>
 <img
-     src='/etc/jupyterhub/custom/logos/datalab-logo.svg' />
+     src='https://datalab.noirlab.edu/account/static/img/datalab-logo.svg' />
 </div>
 
 


### PR DESCRIPTION
My previous assessment on it working because of https I think has nothing to do. I'm confused as to what made it work.

So I'm going back to providing the log via external source.

A more detailed explanation can be found here:

https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/691 https://github.com/jupyterhub/jupyterhub/issues/1385#issuecomment-326966823 https://discourse.jupyter.org/t/customizing-jupyterhub-on-kubernetes/1769